### PR TITLE
change telegraf to use webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ yarn lint
 ```
 yarn lint-fix
 ```
+
+## Production Deployment
+
+Set following variables in your production environment:
+
+1. `BOT_TOKEN`: Same as above
+1. `WEBHOOK_DOMAIN`: Domain of your web server. It be running on port 80 and support HTTPS. Example value:`mydomain.com`

--- a/src/controllers/tracker.controller.js
+++ b/src/controllers/tracker.controller.js
@@ -1,10 +1,12 @@
 import commandMap from "./commands/commandMap.js";
 
-export function tracker(bot) {
+export function tracker(bot, isWebhookMode) {
   console.log("commands", commandMap);
   Object.entries(commandMap).forEach((entry) => {
     bot.command(entry[0], entry[1]);
   });
 
-  bot.launch();
+  if (!isWebhookMode) {
+    bot.launch();
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,19 @@ const app = express();
 dotenv.config();
 
 const bot = new Telegraf(process.env.BOT_TOKEN);
-tracker(bot);
+
+let isWebhookMode = false;
+if (process.env.WEBHOOK_DOMAIN != null) {
+  console.log(
+    "webhook domain is set. probably a production env. going webhook mode"
+  );
+  isWebhookMode = true;
+  const secretPath = `/telegraf/${bot.secretPathComponent()}`;
+  bot.telegram.setWebhook(`https://${process.env.WEBHOOK_DOMAIN}${secretPath}`);
+  app.use(bot.webhookCallback(secretPath));
+}
+
+tracker(bot, isWebhookMode);
 
 app.get("/health", (req, res) => {
   // health, not helth ;)


### PR DESCRIPTION
it still uses default polling mode if the env doesn't specify a hook domain. easier to run and test locally with the polling mode

note to reviewers: you can test that the webhook mode is working using ngrok

1. Download [ngrok](https://ngrok.com/)
2. Put ngrok URL as `WEBHOOK_DOMAIN` in `.env`. This will make the bot run in "production mode", if you will
3. Send message to the bot, and ngrok log should have a log entry with 200 code and you should get the response as usual

So the bot behavior is same but when using webhooks, the server doesn't keep asking telegram for updates. Instead telegram calls our webhook whenever there's any new message. Saves a lot on server resources. Locally it still runs polling mode

Closes #22 